### PR TITLE
chore(deps): bump projen from 0.97.2 to 0.98.34

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -2,7 +2,7 @@
 
 * text=auto eol=lf
 *.snap linguist-generated
-/.eslintrc.json linguist-generated
+/.eslintrc.json linguist-generated linguist-language=JSON-with-Comments
 /.gitattributes linguist-generated
 /.github/pull_request_template.md linguist-generated
 /.github/workflows/build.yml linguist-generated
@@ -21,5 +21,5 @@
 /LICENSE linguist-generated
 /package-lock.json linguist-generated
 /package.json linguist-generated
-/tsconfig.dev.json linguist-generated
-/tsconfig.json linguist-generated
+/tsconfig.dev.json linguist-generated linguist-language=JSON-with-Comments
+/tsconfig.json linguist-generated linguist-language=JSON-with-Comments

--- a/.projen/deps.json
+++ b/.projen/deps.json
@@ -56,7 +56,7 @@
     },
     {
       "name": "projen",
-      "version": "0.97.2",
+      "version": "0.98.34",
       "type": "build"
     },
     {

--- a/.projen/tasks.json
+++ b/.projen/tasks.json
@@ -118,7 +118,8 @@
       "name": "eslint",
       "description": "Runs eslint against the codebase",
       "env": {
-        "ESLINT_USE_FLAT_CONFIG": "false"
+        "ESLINT_USE_FLAT_CONFIG": "false",
+        "NODE_NO_WARNINGS": "1"
       },
       "steps": [
         {
@@ -214,7 +215,7 @@
       },
       "steps": [
         {
-          "exec": "npx npm-check-updates@16 --upgrade --target=minor --peer --no-deprecated --dep=dev,peer,prod,optional --filter=@types/jest,@types/node,esbuild,eslint-import-resolver-typescript,eslint-plugin-import,jest,ts-jest,ts-node,typescript"
+          "exec": "npx npm-check-updates@18 --upgrade --target=minor --peer --no-deprecated --dep=dev,peer,prod,optional --filter=@types/jest,@types/node,esbuild,eslint-import-resolver-typescript,eslint-plugin-import,jest,ts-jest,ts-node,typescript"
         },
         {
           "exec": "npm install"

--- a/.projenrc.ts
+++ b/.projenrc.ts
@@ -40,7 +40,7 @@ const project = new awscdk.AwsCdkTypeScriptApp({
   deps: [
     '@ogis-rd/awscdk-nat-lib@^0.1.1',
   ],
-  projenVersion: '0.97.2',
+  projenVersion: '0.98.34',
 
   context: {
     [StackSettings.KEY]: stackSettings,

--- a/package-lock.json
+++ b/package-lock.json
@@ -26,7 +26,7 @@
         "eslint-plugin-import": "^2.32.0",
         "jest": "^29.7.0",
         "jest-junit": "^16",
-        "projen": "0.97.2",
+        "projen": "0.98.34",
         "ts-jest": "^29.4.6",
         "ts-node": "^10.9.2",
         "typescript": "^5.9.3"
@@ -7062,9 +7062,9 @@
       }
     },
     "node_modules/projen": {
-      "version": "0.97.2",
-      "resolved": "https://registry.npmjs.org/projen/-/projen-0.97.2.tgz",
-      "integrity": "sha512-0G+CTi5lyYF9rI5uZe8r9orXOhO7i3/k5RKtysRCf7NfkJhLlhelDFB2oV5OG95RmmytfbBZvkAqcBmcduCiWA==",
+      "version": "0.98.34",
+      "resolved": "https://registry.npmjs.org/projen/-/projen-0.98.34.tgz",
+      "integrity": "sha512-52JX/fz5iZiy+F5r5MJjpLMtUM1sryQZVGGAVRruR6G6r8J8L/QBLXKnjss7gLPs0hbAcsCx1Zu81lh6Vnm0rA==",
       "bundleDependencies": [
         "@iarna/toml",
         "case",
@@ -7096,7 +7096,7 @@
         "parse-conflict-json": "^4.0.0",
         "semver": "^7.7.3",
         "shx": "^0.4.0",
-        "xmlbuilder2": "^3.1.1",
+        "xmlbuilder2": "^4.0.3",
         "yaml": "^2.2.2",
         "yargs": "^17.7.2"
       },
@@ -7152,51 +7152,51 @@
       }
     },
     "node_modules/projen/node_modules/@oozcitak/dom": {
-      "version": "1.15.10",
+      "version": "2.0.2",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
-        "@oozcitak/infra": "1.0.8",
-        "@oozcitak/url": "1.0.4",
-        "@oozcitak/util": "8.3.8"
+        "@oozcitak/infra": "^2.0.2",
+        "@oozcitak/url": "^3.0.0",
+        "@oozcitak/util": "^10.0.0"
       },
       "engines": {
-        "node": ">=8.0"
+        "node": ">=20.0"
       }
     },
     "node_modules/projen/node_modules/@oozcitak/infra": {
-      "version": "1.0.8",
+      "version": "2.0.2",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
-        "@oozcitak/util": "8.3.8"
+        "@oozcitak/util": "^10.0.0"
       },
       "engines": {
-        "node": ">=6.0"
+        "node": ">=20.0"
       }
     },
     "node_modules/projen/node_modules/@oozcitak/url": {
-      "version": "1.0.4",
+      "version": "3.0.0",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
-        "@oozcitak/infra": "1.0.8",
-        "@oozcitak/util": "8.3.8"
+        "@oozcitak/infra": "^2.0.2",
+        "@oozcitak/util": "^10.0.0"
       },
       "engines": {
-        "node": ">=8.0"
+        "node": ">=20.0"
       }
     },
     "node_modules/projen/node_modules/@oozcitak/util": {
-      "version": "8.3.8",
+      "version": "10.0.0",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
       "engines": {
-        "node": ">=8.0"
+        "node": ">=20.0"
       }
     },
     "node_modules/projen/node_modules/ansi-regex": {
@@ -7224,13 +7224,10 @@
       }
     },
     "node_modules/projen/node_modules/argparse": {
-      "version": "1.0.10",
+      "version": "2.0.1",
       "dev": true,
       "inBundle": true,
-      "license": "MIT",
-      "dependencies": {
-        "sprintf-js": "~1.0.2"
-      }
+      "license": "Python-2.0"
     },
     "node_modules/projen/node_modules/array-timsort": {
       "version": "1.0.3",
@@ -7372,82 +7369,6 @@
         "node": ">=4"
       }
     },
-    "node_modules/projen/node_modules/execa": {
-      "version": "1.0.0",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "dependencies": {
-        "cross-spawn": "^6.0.0",
-        "get-stream": "^4.0.0",
-        "is-stream": "^1.1.0",
-        "npm-run-path": "^2.0.0",
-        "p-finally": "^1.0.0",
-        "signal-exit": "^3.0.0",
-        "strip-eof": "^1.0.0"
-      },
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/projen/node_modules/execa/node_modules/cross-spawn": {
-      "version": "6.0.6",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "dependencies": {
-        "nice-try": "^1.0.4",
-        "path-key": "^2.0.1",
-        "semver": "^5.5.0",
-        "shebang-command": "^1.2.0",
-        "which": "^1.2.9"
-      },
-      "engines": {
-        "node": ">=4.8"
-      }
-    },
-    "node_modules/projen/node_modules/execa/node_modules/semver": {
-      "version": "5.7.2",
-      "dev": true,
-      "inBundle": true,
-      "license": "ISC",
-      "bin": {
-        "semver": "bin/semver"
-      }
-    },
-    "node_modules/projen/node_modules/execa/node_modules/shebang-command": {
-      "version": "1.2.0",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "dependencies": {
-        "shebang-regex": "^1.0.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/projen/node_modules/execa/node_modules/shebang-regex": {
-      "version": "1.0.0",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/projen/node_modules/execa/node_modules/which": {
-      "version": "1.3.1",
-      "dev": true,
-      "inBundle": true,
-      "license": "ISC",
-      "dependencies": {
-        "isexe": "^2.0.0"
-      },
-      "bin": {
-        "which": "bin/which"
-      }
-    },
     "node_modules/projen/node_modules/fast-glob": {
       "version": "3.3.3",
       "dev": true,
@@ -7462,6 +7383,18 @@
       },
       "engines": {
         "node": ">=8.6.0"
+      }
+    },
+    "node_modules/projen/node_modules/fast-glob/node_modules/glob-parent": {
+      "version": "5.1.2",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "is-glob": "^4.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
       }
     },
     "node_modules/projen/node_modules/fast-json-patch": {
@@ -7507,30 +7440,6 @@
       "license": "ISC",
       "engines": {
         "node": "6.* || 8.* || >= 10.*"
-      }
-    },
-    "node_modules/projen/node_modules/get-stream": {
-      "version": "4.1.0",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "dependencies": {
-        "pump": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/projen/node_modules/glob-parent": {
-      "version": "5.1.2",
-      "dev": true,
-      "inBundle": true,
-      "license": "ISC",
-      "dependencies": {
-        "is-glob": "^4.0.1"
-      },
-      "engines": {
-        "node": ">= 6"
       }
     },
     "node_modules/projen/node_modules/has-flag": {
@@ -7635,15 +7544,6 @@
         "node": ">=0.12.0"
       }
     },
-    "node_modules/projen/node_modules/is-stream": {
-      "version": "1.1.0",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/projen/node_modules/isexe": {
       "version": "2.0.0",
       "dev": true,
@@ -7651,16 +7551,24 @@
       "license": "ISC"
     },
     "node_modules/projen/node_modules/js-yaml": {
-      "version": "3.14.1",
+      "version": "4.1.1",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
-        "argparse": "^1.0.7",
-        "esprima": "^4.0.0"
+        "argparse": "^2.0.1"
       },
       "bin": {
         "js-yaml": "bin/js-yaml.js"
+      }
+    },
+    "node_modules/projen/node_modules/json-parse-even-better-errors": {
+      "version": "4.0.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.17.0 || >=20.5.0"
       }
     },
     "node_modules/projen/node_modules/just-diff": {
@@ -7712,18 +7620,6 @@
       "inBundle": true,
       "license": "MIT"
     },
-    "node_modules/projen/node_modules/npm-run-path": {
-      "version": "2.0.2",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "dependencies": {
-        "path-key": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
     "node_modules/projen/node_modules/once": {
       "version": "1.4.0",
       "dev": true,
@@ -7754,24 +7650,6 @@
       },
       "engines": {
         "node": "^18.17.0 || >=20.5.0"
-      }
-    },
-    "node_modules/projen/node_modules/parse-conflict-json/node_modules/json-parse-even-better-errors": {
-      "version": "4.0.0",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "engines": {
-        "node": "^18.17.0 || >=20.5.0"
-      }
-    },
-    "node_modules/projen/node_modules/path-key": {
-      "version": "2.0.1",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=4"
       }
     },
     "node_modules/projen/node_modules/path-parse": {
@@ -7852,12 +7730,12 @@
       }
     },
     "node_modules/projen/node_modules/resolve": {
-      "version": "1.22.10",
+      "version": "1.22.11",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
-        "is-core-module": "^2.16.0",
+        "is-core-module": "^2.16.1",
         "path-parse": "^1.0.7",
         "supports-preserve-symlinks-flag": "^1.0.0"
       },
@@ -7934,6 +7812,124 @@
         "node": ">=18"
       }
     },
+    "node_modules/projen/node_modules/shelljs/node_modules/cross-spawn": {
+      "version": "6.0.6",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "nice-try": "^1.0.4",
+        "path-key": "^2.0.1",
+        "semver": "^5.5.0",
+        "shebang-command": "^1.2.0",
+        "which": "^1.2.9"
+      },
+      "engines": {
+        "node": ">=4.8"
+      }
+    },
+    "node_modules/projen/node_modules/shelljs/node_modules/execa": {
+      "version": "1.0.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "cross-spawn": "^6.0.0",
+        "get-stream": "^4.0.0",
+        "is-stream": "^1.1.0",
+        "npm-run-path": "^2.0.0",
+        "p-finally": "^1.0.0",
+        "signal-exit": "^3.0.0",
+        "strip-eof": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/projen/node_modules/shelljs/node_modules/get-stream": {
+      "version": "4.1.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "pump": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/projen/node_modules/shelljs/node_modules/is-stream": {
+      "version": "1.1.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/projen/node_modules/shelljs/node_modules/npm-run-path": {
+      "version": "2.0.2",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/projen/node_modules/shelljs/node_modules/path-key": {
+      "version": "2.0.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/projen/node_modules/shelljs/node_modules/semver": {
+      "version": "5.7.2",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver"
+      }
+    },
+    "node_modules/projen/node_modules/shelljs/node_modules/shebang-command": {
+      "version": "1.2.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "shebang-regex": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/projen/node_modules/shelljs/node_modules/shebang-regex": {
+      "version": "1.0.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/projen/node_modules/shelljs/node_modules/which": {
+      "version": "1.3.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "which": "bin/which"
+      }
+    },
     "node_modules/projen/node_modules/shx": {
       "version": "0.4.0",
       "dev": true,
@@ -7955,12 +7951,6 @@
       "dev": true,
       "inBundle": true,
       "license": "ISC"
-    },
-    "node_modules/projen/node_modules/sprintf-js": {
-      "version": "1.0.3",
-      "dev": true,
-      "inBundle": true,
-      "license": "BSD-3-Clause"
     },
     "node_modules/projen/node_modules/string-width": {
       "version": "4.2.3",
@@ -8057,18 +8047,18 @@
       "license": "ISC"
     },
     "node_modules/projen/node_modules/xmlbuilder2": {
-      "version": "3.1.1",
+      "version": "4.0.3",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
-        "@oozcitak/dom": "1.15.10",
-        "@oozcitak/infra": "1.0.8",
-        "@oozcitak/util": "8.3.8",
-        "js-yaml": "3.14.1"
+        "@oozcitak/dom": "^2.0.2",
+        "@oozcitak/infra": "^2.0.2",
+        "@oozcitak/util": "^10.0.0",
+        "js-yaml": "^4.1.1"
       },
       "engines": {
-        "node": ">=12.0"
+        "node": ">=20.0"
       }
     },
     "node_modules/projen/node_modules/y18n": {
@@ -8081,7 +8071,7 @@
       }
     },
     "node_modules/projen/node_modules/yaml": {
-      "version": "2.8.1",
+      "version": "2.8.2",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -8090,6 +8080,9 @@
       },
       "engines": {
         "node": ">= 14.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/eemeli"
       }
     },
     "node_modules/projen/node_modules/yargs": {

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "eslint-plugin-import": "^2.32.0",
     "jest": "^29.7.0",
     "jest-junit": "^16",
-    "projen": "0.97.2",
+    "projen": "0.98.34",
     "ts-jest": "^29.4.6",
     "ts-node": "^10.9.2",
     "typescript": "^5.9.3"


### PR DESCRIPTION
Upgrade projen and apply the following changes:

* Bump `npm-check-updates` from 16 to 18
* Add `NODE_NO_WARNINGS=1` environment variable to suppress warnings
* Modify `.gitattributes` to help GitHub render some JSON files with proper syntax highlighting instead of treating them as regular JSON

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license.
